### PR TITLE
New getstats

### DIFF
--- a/scripts/checkCoverage.sh
+++ b/scripts/checkCoverage.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./node_modules/.bin/istanbul check-coverage --branches 47 --lines 60 --functions 73 coverage/coverage.raw.json
+./node_modules/.bin/istanbul check-coverage --branches 75 --lines 86 --functions 85 coverage/coverage.raw.json

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -3,4 +3,4 @@
 --ui bdd
 --colors
 --compilers js:babel-core/register
-test/test.js
+test/test*.js

--- a/test/mock-initial-stats-spec.json
+++ b/test/mock-initial-stats-spec.json
@@ -1,0 +1,640 @@
+[
+    {
+        "key": "googLibjingleSession_3024778249717055640",
+        "value": {
+            "id": "googLibjingleSession_3024778249717055640",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googLibjingleSession",
+            "googInitiator": "false"
+        }
+    },
+    {
+        "key": "googTrack_c25d5324-45ef-4653-8444-25b468afa76b",
+        "value": {
+            "id": "googTrack_c25d5324-45ef-4653-8444-25b468afa76b",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googTrack",
+            "googTrackId": "c25d5324-45ef-4653-8444-25b468afa76b"
+        }
+    },
+    {
+        "key": "googTrack_91e5b7dc-28b7-45a5-8000-5b8631369493",
+        "value": {
+            "id": "googTrack_91e5b7dc-28b7-45a5-8000-5b8631369493",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googTrack",
+            "googTrackId": "91e5b7dc-28b7-45a5-8000-5b8631369493"
+        }
+    },
+    {
+        "key": "googTrack_47d11ec3-fc64-44ab-a839-1659aadf8d48",
+        "value": {
+            "id": "googTrack_47d11ec3-fc64-44ab-a839-1659aadf8d48",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googTrack",
+            "googTrackId": "47d11ec3-fc64-44ab-a839-1659aadf8d48"
+        }
+    },
+    {
+        "key": "googTrack_3b137021-f636-4767-bd02-d5361708047d",
+        "value": {
+            "id": "googTrack_3b137021-f636-4767-bd02-d5361708047d",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googTrack",
+            "googTrackId": "3b137021-f636-4767-bd02-d5361708047d"
+        }
+    },
+    {
+        "key": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+        "value": {
+            "id": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCertificate",
+            "googFingerprint": "B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+            "googFingerprintAlgorithm": "sha-256",
+            "googDerBase64": "MIIBFTCBvaADAgECAgkAjk/glew1VugwCgYIKoZIzj0EAwIwETEPMA0GA1UEAwwGV2ViUlRDMB4XDTE2MDYxNjEyMTMzNVoXDTE2MDcxNzEyMTMzNVowETEPMA0GA1UEAwwGV2ViUlRDMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV1SaRCZhWrVpOWtyFvKjALDF2AUiLcaQW44UQyDtWGY9ZvyB/r9IbVtMZQaWzAhgo3/MqnxAV9aI/V/LavFm8zAKBggqhkjOPQQDAgNHADBEAiAb6LGObQ+HZNHIBwZMyHnXojmRAkQtna1GNqKdbtlFnAIgLy+MS5LYT/ZJPzKlo+MmGzdZ8bd22NwN4C5waepAVd8="
+        }
+    },
+    {
+        "key": "Channel-audio-1",
+        "value": {
+            "id": "Channel-audio-1",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "1",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "Channel-audio-2",
+        "value": {
+            "id": "Channel-audio-2",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "2",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "Channel-data-1",
+        "value": {
+            "id": "Channel-data-1",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "1",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "Channel-video-1",
+        "value": {
+            "id": "Channel-video-1",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googComponent",
+            "googComponent": "1",
+            "remoteCertificateId": "googCertificate_C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+            "selectedCandidatePairId": "Conn-video-1-0",
+            "dtlsCipher": "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+            "srtpCipher": "AES_CM_128_HMAC_SHA1_80"
+        }
+    },
+    {
+        "key": "Channel-video-2",
+        "value": {
+            "id": "Channel-video-2",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "2",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "ssrc_2422518318_recv",
+        "value": {
+            "id": "ssrc_2422518318_recv",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "ssrc",
+            "googDecodingCTN": "0",
+            "packetsLost": "0",
+            "googSecondaryDecodedRate": "0",
+            "googDecodingPLC": "0",
+            "packetsReceived": "4",
+            "googExpandRate": "0",
+            "googJitterReceived": "0",
+            "googDecodingCNG": "0",
+            "ssrc": "2422518318",
+            "googPreferredJitterBufferMs": "120",
+            "googSpeechExpandRate": "0",
+            "googTrackId": "c25d5324-45ef-4653-8444-25b468afa76b",
+            "transportId": "Channel-video-1",
+            "mediaType": "audio",
+            "googDecodingPLCCNG": "0",
+            "googCodecName": "opus",
+            "googDecodingNormal": "0",
+            "audioOutputLevel": "0",
+            "googAccelerateRate": "0",
+            "bytesReceived": "390",
+            "googCurrentDelayMs": "0",
+            "googDecodingCTSG": "0",
+            "googCaptureStartNtpTimeMs": "0",
+            "googPreemptiveExpandRate": "0",
+            "googJitterBufferMs": "80"
+        }
+    },
+    {
+        "key": "ssrc_5896877_recv",
+        "value": {
+            "id": "ssrc_5896877_recv",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "ssrc",
+            "googCaptureStartNtpTimeMs": "0",
+            "googTargetDelayMs": "0",
+            "packetsLost": "0",
+            "googDecodeMs": "0",
+            "googFrameHeightReceived": "-1",
+            "packetsReceived": "13",
+            "ssrc": "5896877",
+            "googRenderDelayMs": "10",
+            "googMaxDecodeMs": "0",
+            "googTrackId": "91e5b7dc-28b7-45a5-8000-5b8631369493",
+            "googFrameWidthReceived": "-1",
+            "codecImplementationName": "unknown",
+            "transportId": "Channel-video-1",
+            "mediaType": "video",
+            "googCodecName": "",
+            "googFrameRateReceived": "0",
+            "googFrameRateDecoded": "0",
+            "googNacksSent": "0",
+            "googFirsSent": "0",
+            "bytesReceived": "14742",
+            "googCurrentDelayMs": "0",
+            "googMinPlayoutDelayMs": "0",
+            "googFrameRateOutput": "0",
+            "googJitterBufferMs": "0",
+            "googPlisSent": "1"
+        }
+    },
+    {
+        "key": "bweforvideo",
+        "value": {
+            "id": "bweforvideo",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "VideoBwe",
+            "googActualEncBitrate": "0",
+            "googAvailableSendBandwidth": "300000",
+            "googRetransmitBitrate": "0",
+            "googAvailableReceiveBandwidth": "0",
+            "googTargetEncBitrate": "0",
+            "googBucketDelay": "1",
+            "googTransmitBitrate": "0"
+        }
+    },
+    {
+        "key": "googCertificate_C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+        "value": {
+            "id": "googCertificate_C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCertificate",
+            "googFingerprint": "C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+            "googFingerprintAlgorithm": "sha-1",
+            "googDerBase64": "MIIBsTCCARqgAwIBAgIGAVVZLuIZMA0GCSqGSIb3DQEBBQUAMBwxGjAYBgNVBAMMEUpWQiAwLjEuYnVpbGQuU1ZOMB4XDTE2MDYxNTEyMjgxMloXDTE2MDYyMzEyMjgxMlowHDEaMBgGA1UEAwwRSlZCIDAuMS5idWlsZC5TVk4wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKu0aXTYaQGUyEU75jO/OqPEQs1IIHOlOEcTGEO1WLHjbtpjSjqW3ECWwHh/MTEoslp5HsXpuyjcAwXOCbN4Nz3Z3UmGsh7Z9z29TZyTshELVDnVjxjgLOQpg43ywkZAQB/nI1Caw/3dAplMrzQa/NJ2uP3WxLNBuDt+wzeHG+1pAgMBAAEwDQYJKoZIhvcNAQEFBQADgYEAMNT5J9WK8EnJK/ZzF9kGyX+4HSwu/sJe/Uu3gN+miNdvSdQxMp9x9HTq6YCmMEDZUM5TgcuU6yTTEt7vehbxsgfjF8pamrE+eUUSjyfopwSi4Y+iktxZMoZXDlty8Xe43ZfE6pkBYF7kMDRSfvthtYPq6NOBGi4/0WusgAxHOiw="
+        }
+    },
+    {
+        "key": "Conn-video-1-0",
+        "value": {
+            "id": "Conn-video-1-0",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCandidatePair",
+            "responsesSent": "3",
+            "requestsReceived": "3",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "true",
+            "googLocalAddress": "172.18.176.255:64985",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "true",
+            "requestsSent": "1",
+            "googRemoteAddress": "54.165.147.171:10000",
+            "googRtt": "2253",
+            "googActiveConnection": "true",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "16972",
+            "responsesReceived": "1",
+            "remoteCandidateId": "Cand-INmwpWWt",
+            "localCandidateId": "Cand-wT+oPLPA",
+            "bytesSent": "3867",
+            "packetsSent": "10"
+        }
+    },
+    {
+        "key": "Cand-wT+oPLPA",
+        "value": {
+            "id": "Cand-wT+oPLPA",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "64985",
+            "networkType": "lan",
+            "ipAddress": "172.18.176.255",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2122260223"
+        }
+    },
+    {
+        "key": "Cand-INmwpWWt",
+        "value": {
+            "id": "Cand-INmwpWWt",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "10000",
+            "ipAddress": "54.165.147.171",
+            "transport": "udp",
+            "candidateType": "serverreflexive",
+            "priority": "1677724415"
+        }
+    },
+    {
+        "key": "Conn-video-1-1",
+        "value": {
+            "id": "Conn-video-1-1",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "172.18.176.255:64985",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "172.18.12.231:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-tmvpC7tc",
+            "localCandidateId": "Cand-wT+oPLPA",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-tmvpC7tc",
+        "value": {
+            "id": "Cand-tmvpC7tc",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "10000",
+            "ipAddress": "172.18.12.231",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2130706431"
+        }
+    },
+    {
+        "key": "Conn-video-1-2",
+        "value": {
+            "id": "Conn-video-1-2",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "192.168.64.1:50198",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "172.18.12.231:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-tmvpC7tc",
+            "localCandidateId": "Cand-wOrQ25Vv",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-wOrQ25Vv",
+        "value": {
+            "id": "Cand-wOrQ25Vv",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "50198",
+            "networkType": "lan",
+            "ipAddress": "192.168.64.1",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2122194687"
+        }
+    },
+    {
+        "key": "Conn-video-1-3",
+        "value": {
+            "id": "Conn-video-1-3",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "false",
+            "googLocalAddress": "192.168.64.1:50198",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "54.165.147.171:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-INmwpWWt",
+            "localCandidateId": "Cand-wOrQ25Vv",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Conn-video-1-4",
+        "value": {
+            "id": "Conn-video-1-4",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "172.18.176.255:9",
+            "consentRequestsSent": "0",
+            "googTransportType": "tcp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "0",
+            "googRemoteAddress": "172.18.12.231:4443",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-37oGWafi",
+            "localCandidateId": "Cand-MLrYwp/3",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-MLrYwp/3",
+        "value": {
+            "id": "Cand-MLrYwp/3",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "9",
+            "networkType": "lan",
+            "ipAddress": "172.18.176.255",
+            "transport": "tcp",
+            "candidateType": "host",
+            "priority": "1518280447"
+        }
+    },
+    {
+        "key": "Cand-37oGWafi",
+        "value": {
+            "id": "Cand-37oGWafi",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "4443",
+            "ipAddress": "172.18.12.231",
+            "transport": "ssltcp",
+            "candidateType": "host",
+            "priority": "2130706431"
+        }
+    },
+    {
+        "key": "Conn-video-1-5",
+        "value": {
+            "id": "Conn-video-1-5",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "false",
+            "googLocalAddress": "172.18.176.255:9",
+            "consentRequestsSent": "1",
+            "googTransportType": "tcp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "54.165.147.171:4443",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-4LkPxWAa",
+            "localCandidateId": "Cand-MLrYwp/3",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-4LkPxWAa",
+        "value": {
+            "id": "Cand-4LkPxWAa",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "4443",
+            "ipAddress": "54.165.147.171",
+            "transport": "ssltcp",
+            "candidateType": "serverreflexive",
+            "priority": "1694498815"
+        }
+    },
+    {
+        "key": "Conn-video-1-6",
+        "value": {
+            "id": "Conn-video-1-6",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "192.168.64.1:9",
+            "consentRequestsSent": "0",
+            "googTransportType": "tcp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "0",
+            "googRemoteAddress": "172.18.12.231:4443",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-37oGWafi",
+            "localCandidateId": "Cand-FBsLuZbK",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-FBsLuZbK",
+        "value": {
+            "id": "Cand-FBsLuZbK",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "9",
+            "networkType": "lan",
+            "ipAddress": "192.168.64.1",
+            "transport": "tcp",
+            "candidateType": "host",
+            "priority": "1518214911"
+        }
+    },
+    {
+        "key": "Conn-video-1-7",
+        "value": {
+            "id": "Conn-video-1-7",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "54.210.139.169:61927",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "relay",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "172.18.12.231:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-tmvpC7tc",
+            "localCandidateId": "Cand-YiNpVTvy",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-YiNpVTvy",
+        "value": {
+            "id": "Cand-YiNpVTvy",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "61927",
+            "networkType": "lan",
+            "ipAddress": "54.210.139.169",
+            "transport": "udp",
+            "candidateType": "relayed",
+            "priority": "41885439"
+        }
+    },
+    {
+        "key": "Conn-video-1-8",
+        "value": {
+            "id": "Conn-video-1-8",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "false",
+            "googLocalAddress": "54.210.139.169:61927",
+            "consentRequestsSent": "0",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "relay",
+            "googWritable": "false",
+            "requestsSent": "0",
+            "googRemoteAddress": "54.165.147.171:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-INmwpWWt",
+            "localCandidateId": "Cand-YiNpVTvy",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "ssrc_3923207368_send",
+        "value": {
+            "id": "ssrc_3923207368_send",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "ssrc",
+            "audioInputLevel": "616",
+            "transportId": "Channel-video-1",
+            "mediaType": "audio",
+            "googEchoCancellationReturnLoss": "-100",
+            "googCodecName": "opus",
+            "googTrackId": "47d11ec3-fc64-44ab-a839-1659aadf8d48",
+            "ssrc": "3923207368",
+            "googTypingNoiseState": "false",
+            "googEchoCancellationReturnLossEnhancement": "-100",
+            "packetsSent": "2",
+            "bytesSent": "232",
+            "aecDivergentFilterFraction": "-1"
+        }
+    },
+    {
+        "key": "ssrc_1169081302_send",
+        "value": {
+            "id": "ssrc_1169081302_send",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "ssrc",
+            "googFrameHeightInput": "480",
+            "googFrameWidthInput": "640",
+            "googFrameWidthSent": "640",
+            "packetsLost": "0",
+            "googRtt": "0",
+            "googEncodeUsagePercent": "0",
+            "googCpuLimitedResolution": "false",
+            "googNacksReceived": "0",
+            "googViewLimitedResolution": "false",
+            "googBandwidthLimitedResolution": "false",
+            "googPlisReceived": "0",
+            "googAvgEncodeMs": "0",
+            "googTrackId": "3b137021-f636-4767-bd02-d5361708047d",
+            "googFrameRateInput": "0",
+            "codecImplementationName": "unknown",
+            "transportId": "Channel-video-1",
+            "mediaType": "video",
+            "googFrameHeightSent": "480",
+            "googFrameRateSent": "0",
+            "googCodecName": "VP8",
+            "googAdaptationChanges": "0",
+            "ssrc": "1169081302",
+            "googFirsReceived": "0",
+            "packetsSent": "2",
+            "bytesSent": "2174"
+        }
+    }
+]

--- a/test/mock-stats-1-spec.json
+++ b/test/mock-stats-1-spec.json
@@ -1,0 +1,652 @@
+[
+    {
+        "key": "googLibjingleSession_3024778249717055640",
+        "value": {
+            "id": "googLibjingleSession_3024778249717055640",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googLibjingleSession",
+            "googInitiator": "false"
+        }
+    },
+    {
+        "key": "googTrack_c25d5324-45ef-4653-8444-25b468afa76b",
+        "value": {
+            "id": "googTrack_c25d5324-45ef-4653-8444-25b468afa76b",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googTrack",
+            "googTrackId": "c25d5324-45ef-4653-8444-25b468afa76b"
+        }
+    },
+    {
+        "key": "googTrack_91e5b7dc-28b7-45a5-8000-5b8631369493",
+        "value": {
+            "id": "googTrack_91e5b7dc-28b7-45a5-8000-5b8631369493",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googTrack",
+            "googTrackId": "91e5b7dc-28b7-45a5-8000-5b8631369493"
+        }
+    },
+    {
+        "key": "googTrack_47d11ec3-fc64-44ab-a839-1659aadf8d48",
+        "value": {
+            "id": "googTrack_47d11ec3-fc64-44ab-a839-1659aadf8d48",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googTrack",
+            "googTrackId": "47d11ec3-fc64-44ab-a839-1659aadf8d48"
+        }
+    },
+    {
+        "key": "googTrack_3b137021-f636-4767-bd02-d5361708047d",
+        "value": {
+            "id": "googTrack_3b137021-f636-4767-bd02-d5361708047d",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googTrack",
+            "googTrackId": "3b137021-f636-4767-bd02-d5361708047d"
+        }
+    },
+    {
+        "key": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+        "value": {
+            "id": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCertificate",
+            "googFingerprint": "B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+            "googFingerprintAlgorithm": "sha-256",
+            "googDerBase64": "MIIBFTCBvaADAgECAgkAjk/glew1VugwCgYIKoZIzj0EAwIwETEPMA0GA1UEAwwGV2ViUlRDMB4XDTE2MDYxNjEyMTMzNVoXDTE2MDcxNzEyMTMzNVowETEPMA0GA1UEAwwGV2ViUlRDMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV1SaRCZhWrVpOWtyFvKjALDF2AUiLcaQW44UQyDtWGY9ZvyB/r9IbVtMZQaWzAhgo3/MqnxAV9aI/V/LavFm8zAKBggqhkjOPQQDAgNHADBEAiAb6LGObQ+HZNHIBwZMyHnXojmRAkQtna1GNqKdbtlFnAIgLy+MS5LYT/ZJPzKlo+MmGzdZ8bd22NwN4C5waepAVd8="
+        }
+    },
+    {
+        "key": "Channel-audio-1",
+        "value": {
+            "id": "Channel-audio-1",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "1",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "Channel-audio-2",
+        "value": {
+            "id": "Channel-audio-2",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "2",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "Channel-data-1",
+        "value": {
+            "id": "Channel-data-1",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "1",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "Channel-video-1",
+        "value": {
+            "id": "Channel-video-1",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googComponent",
+            "googComponent": "1",
+            "remoteCertificateId": "googCertificate_C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+            "selectedCandidatePairId": "Conn-video-1-0",
+            "dtlsCipher": "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+            "srtpCipher": "AES_CM_128_HMAC_SHA1_80"
+        }
+    },
+    {
+        "key": "Channel-video-2",
+        "value": {
+            "id": "Channel-video-2",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "2",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "ssrc_2422518318_recv",
+        "value": {
+            "id": "ssrc_2422518318_recv",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "ssrc",
+            "googDecodingCTN": "0",
+            "packetsLost": "0",
+            "googSecondaryDecodedRate": "0",
+            "googDecodingPLC": "0",
+            "packetsReceived": "8",
+            "googExpandRate": "0",
+            "googJitterReceived": "0",
+            "googDecodingCNG": "0",
+            "ssrc": "2422518318",
+            "googPreferredJitterBufferMs": "120",
+            "googSpeechExpandRate": "0",
+            "googTrackId": "c25d5324-45ef-4653-8444-25b468afa76b",
+            "transportId": "Channel-video-1",
+            "mediaType": "audio",
+            "googDecodingPLCCNG": "0",
+            "googCodecName": "opus",
+            "googDecodingNormal": "0",
+            "audioOutputLevel": "0",
+            "googAccelerateRate": "0",
+            "bytesReceived": "772",
+            "googCurrentDelayMs": "0",
+            "googDecodingCTSG": "0",
+            "googCaptureStartNtpTimeMs": "0",
+            "googPreemptiveExpandRate": "0",
+            "googJitterBufferMs": "160"
+        }
+    },
+    {
+        "key": "ssrc_5896877_recv",
+        "value": {
+            "id": "ssrc_5896877_recv",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "ssrc",
+            "googCaptureStartNtpTimeMs": "0",
+            "googTargetDelayMs": "0",
+            "packetsLost": "0",
+            "googDecodeMs": "0",
+            "googFrameHeightReceived": "480",
+            "packetsReceived": "32",
+            "ssrc": "5896877",
+            "googRenderDelayMs": "10",
+            "googMaxDecodeMs": "0",
+            "googTrackId": "91e5b7dc-28b7-45a5-8000-5b8631369493",
+            "googFrameWidthReceived": "640",
+            "codecImplementationName": "libvpx",
+            "transportId": "Channel-video-1",
+            "mediaType": "video",
+            "googCodecName": "VP8",
+            "googFrameRateReceived": "0",
+            "googFrameRateDecoded": "57",
+            "googNacksSent": "0",
+            "googFirsSent": "0",
+            "bytesReceived": "36085",
+            "googCurrentDelayMs": "0",
+            "googMinPlayoutDelayMs": "0",
+            "googFrameRateOutput": "57",
+            "googJitterBufferMs": "0",
+            "googPlisSent": "1"
+        }
+    },
+    {
+        "key": "bweforvideo",
+        "value": {
+            "id": "bweforvideo",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "VideoBwe",
+            "googActualEncBitrate": "0",
+            "googAvailableSendBandwidth": "1859288",
+            "googRetransmitBitrate": "0",
+            "googAvailableReceiveBandwidth": "0",
+            "googTargetEncBitrate": "1700000",
+            "googBucketDelay": "0",
+            "googTransmitBitrate": "155447"
+        }
+    },
+    {
+        "key": "googCertificate_C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+        "value": {
+            "id": "googCertificate_C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCertificate",
+            "googFingerprint": "C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+            "googFingerprintAlgorithm": "sha-1",
+            "googDerBase64": "MIIBsTCCARqgAwIBAgIGAVVZLuIZMA0GCSqGSIb3DQEBBQUAMBwxGjAYBgNVBAMMEUpWQiAwLjEuYnVpbGQuU1ZOMB4XDTE2MDYxNTEyMjgxMloXDTE2MDYyMzEyMjgxMlowHDEaMBgGA1UEAwwRSlZCIDAuMS5idWlsZC5TVk4wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKu0aXTYaQGUyEU75jO/OqPEQs1IIHOlOEcTGEO1WLHjbtpjSjqW3ECWwHh/MTEoslp5HsXpuyjcAwXOCbN4Nz3Z3UmGsh7Z9z29TZyTshELVDnVjxjgLOQpg43ywkZAQB/nI1Caw/3dAplMrzQa/NJ2uP3WxLNBuDt+wzeHG+1pAgMBAAEwDQYJKoZIhvcNAQEFBQADgYEAMNT5J9WK8EnJK/ZzF9kGyX+4HSwu/sJe/Uu3gN+miNdvSdQxMp9x9HTq6YCmMEDZUM5TgcuU6yTTEt7vehbxsgfjF8pamrE+eUUSjyfopwSi4Y+iktxZMoZXDlty8Xe43ZfE6pkBYF7kMDRSfvthtYPq6NOBGi4/0WusgAxHOiw="
+        }
+    },
+    {
+        "key": "Conn-video-1-0",
+        "value": {
+            "id": "Conn-video-1-0",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCandidatePair",
+            "responsesSent": "3",
+            "requestsReceived": "3",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "true",
+            "googLocalAddress": "172.18.176.255:64985",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "true",
+            "requestsSent": "1",
+            "googRemoteAddress": "54.165.147.171:10000",
+            "googRtt": "2253",
+            "googActiveConnection": "true",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "39793",
+            "responsesReceived": "1",
+            "remoteCandidateId": "Cand-INmwpWWt",
+            "localCandidateId": "Cand-wT+oPLPA",
+            "bytesSent": "13080",
+            "packetsSent": "47"
+        }
+    },
+    {
+        "key": "Cand-wT+oPLPA",
+        "value": {
+            "id": "Cand-wT+oPLPA",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "64985",
+            "networkType": "lan",
+            "ipAddress": "172.18.176.255",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2122260223"
+        }
+    },
+    {
+        "key": "Cand-INmwpWWt",
+        "value": {
+            "id": "Cand-INmwpWWt",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "10000",
+            "ipAddress": "54.165.147.171",
+            "transport": "udp",
+            "candidateType": "serverreflexive",
+            "priority": "1677724415"
+        }
+    },
+    {
+        "key": "Conn-video-1-1",
+        "value": {
+            "id": "Conn-video-1-1",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "172.18.176.255:64985",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "172.18.12.231:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-tmvpC7tc",
+            "localCandidateId": "Cand-wT+oPLPA",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-tmvpC7tc",
+        "value": {
+            "id": "Cand-tmvpC7tc",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "10000",
+            "ipAddress": "172.18.12.231",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2130706431"
+        }
+    },
+    {
+        "key": "Conn-video-1-2",
+        "value": {
+            "id": "Conn-video-1-2",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "192.168.64.1:50198",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "172.18.12.231:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-tmvpC7tc",
+            "localCandidateId": "Cand-wOrQ25Vv",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-wOrQ25Vv",
+        "value": {
+            "id": "Cand-wOrQ25Vv",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "50198",
+            "networkType": "lan",
+            "ipAddress": "192.168.64.1",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2122194687"
+        }
+    },
+    {
+        "key": "Conn-video-1-3",
+        "value": {
+            "id": "Conn-video-1-3",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "false",
+            "googLocalAddress": "192.168.64.1:50198",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "54.165.147.171:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-INmwpWWt",
+            "localCandidateId": "Cand-wOrQ25Vv",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Conn-video-1-4",
+        "value": {
+            "id": "Conn-video-1-4",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "172.18.176.255:9",
+            "consentRequestsSent": "0",
+            "googTransportType": "tcp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "0",
+            "googRemoteAddress": "172.18.12.231:4443",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-37oGWafi",
+            "localCandidateId": "Cand-MLrYwp/3",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-MLrYwp/3",
+        "value": {
+            "id": "Cand-MLrYwp/3",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "9",
+            "networkType": "lan",
+            "ipAddress": "172.18.176.255",
+            "transport": "tcp",
+            "candidateType": "host",
+            "priority": "1518280447"
+        }
+    },
+    {
+        "key": "Cand-37oGWafi",
+        "value": {
+            "id": "Cand-37oGWafi",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "4443",
+            "ipAddress": "172.18.12.231",
+            "transport": "ssltcp",
+            "candidateType": "host",
+            "priority": "2130706431"
+        }
+    },
+    {
+        "key": "Conn-video-1-5",
+        "value": {
+            "id": "Conn-video-1-5",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "false",
+            "googLocalAddress": "172.18.176.255:9",
+            "consentRequestsSent": "1",
+            "googTransportType": "tcp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "54.165.147.171:4443",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-4LkPxWAa",
+            "localCandidateId": "Cand-MLrYwp/3",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-4LkPxWAa",
+        "value": {
+            "id": "Cand-4LkPxWAa",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "4443",
+            "ipAddress": "54.165.147.171",
+            "transport": "ssltcp",
+            "candidateType": "serverreflexive",
+            "priority": "1694498815"
+        }
+    },
+    {
+        "key": "Conn-video-1-6",
+        "value": {
+            "id": "Conn-video-1-6",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "192.168.64.1:9",
+            "consentRequestsSent": "0",
+            "googTransportType": "tcp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "0",
+            "googRemoteAddress": "172.18.12.231:4443",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-37oGWafi",
+            "localCandidateId": "Cand-FBsLuZbK",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-FBsLuZbK",
+        "value": {
+            "id": "Cand-FBsLuZbK",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "9",
+            "networkType": "lan",
+            "ipAddress": "192.168.64.1",
+            "transport": "tcp",
+            "candidateType": "host",
+            "priority": "1518214911"
+        }
+    },
+    {
+        "key": "Conn-video-1-7",
+        "value": {
+            "id": "Conn-video-1-7",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "54.210.139.169:61927",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "relay",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "172.18.12.231:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-tmvpC7tc",
+            "localCandidateId": "Cand-YiNpVTvy",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-YiNpVTvy",
+        "value": {
+            "id": "Cand-YiNpVTvy",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "61927",
+            "networkType": "lan",
+            "ipAddress": "54.210.139.169",
+            "transport": "udp",
+            "candidateType": "relayed",
+            "priority": "41885439"
+        }
+    },
+    {
+        "key": "Conn-video-1-8",
+        "value": {
+            "id": "Conn-video-1-8",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "false",
+            "googLocalAddress": "54.210.139.169:61927",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "relay",
+            "googWritable": "false",
+            "requestsSent": "1",
+            "googRemoteAddress": "54.165.147.171:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-INmwpWWt",
+            "localCandidateId": "Cand-YiNpVTvy",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "ssrc_3923207368_send",
+        "value": {
+            "id": "ssrc_3923207368_send",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "ssrc",
+            "audioInputLevel": "639",
+            "transportId": "Channel-video-1",
+            "mediaType": "audio",
+            "googEchoCancellationReturnLoss": "-100",
+            "googCodecName": "opus",
+            "googTrackId": "47d11ec3-fc64-44ab-a839-1659aadf8d48",
+            "ssrc": "3923207368",
+            "googTypingNoiseState": "false",
+            "googEchoCancellationReturnLossEnhancement": "-100",
+            "packetsSent": "6",
+            "bytesSent": "663",
+            "aecDivergentFilterFraction": "-1"
+        }
+    },
+    {
+        "key": "ssrc_1169081302_send",
+        "value": {
+            "id": "ssrc_1169081302_send",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "ssrc",
+            "googFrameHeightInput": "480",
+            "googFrameWidthInput": "640",
+            "googFrameWidthSent": "640",
+            "packetsLost": "0",
+            "googRtt": "0",
+            "googEncodeUsagePercent": "0",
+            "googCpuLimitedResolution": "false",
+            "googNacksReceived": "0",
+            "googViewLimitedResolution": "false",
+            "googBandwidthLimitedResolution": "false",
+            "googPlisReceived": "0",
+            "googAvgEncodeMs": "0",
+            "googTrackId": "3b137021-f636-4767-bd02-d5361708047d",
+            "googFrameRateInput": "0",
+            "codecImplementationName": "unknown",
+            "transportId": "Channel-video-1",
+            "mediaType": "video",
+            "googFrameHeightSent": "480",
+            "googFrameRateSent": "0",
+            "googCodecName": "VP8",
+            "googAdaptationChanges": "0",
+            "ssrc": "1169081302",
+            "googFirsReceived": "0",
+            "packetsSent": "31",
+            "bytesSent": "10277"
+        }
+    },
+    {
+        "key": "datachannel_0",
+        "value": {
+            "id": "datachannel_0",
+            "timestamp": "2016-06-17T12:13:36.466Z",
+            "type": "datachannel",
+            "datachannelid": "0",
+            "protocol": "http://jitsi.org/protocols/colibri",
+            "label": "default",
+            "state": "open"
+        }
+    }
+]

--- a/test/mock-stats-2-spec.json
+++ b/test/mock-stats-2-spec.json
@@ -1,0 +1,657 @@
+[
+    {
+        "key": "googLibjingleSession_3024778249717055640",
+        "value": {
+            "id": "googLibjingleSession_3024778249717055640",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "googLibjingleSession",
+            "googInitiator": "false"
+        }
+    },
+    {
+        "key": "googTrack_c25d5324-45ef-4653-8444-25b468afa76b",
+        "value": {
+            "id": "googTrack_c25d5324-45ef-4653-8444-25b468afa76b",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "googTrack",
+            "googTrackId": "c25d5324-45ef-4653-8444-25b468afa76b"
+        }
+    },
+    {
+        "key": "googTrack_91e5b7dc-28b7-45a5-8000-5b8631369493",
+        "value": {
+            "id": "googTrack_91e5b7dc-28b7-45a5-8000-5b8631369493",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "googTrack",
+            "googTrackId": "91e5b7dc-28b7-45a5-8000-5b8631369493"
+        }
+    },
+    {
+        "key": "googTrack_47d11ec3-fc64-44ab-a839-1659aadf8d48",
+        "value": {
+            "id": "googTrack_47d11ec3-fc64-44ab-a839-1659aadf8d48",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "googTrack",
+            "googTrackId": "47d11ec3-fc64-44ab-a839-1659aadf8d48"
+        }
+    },
+    {
+        "key": "googTrack_3b137021-f636-4767-bd02-d5361708047d",
+        "value": {
+            "id": "googTrack_3b137021-f636-4767-bd02-d5361708047d",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "googTrack",
+            "googTrackId": "3b137021-f636-4767-bd02-d5361708047d"
+        }
+    },
+    {
+        "key": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+        "value": {
+            "id": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "googCertificate",
+            "googFingerprint": "B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+            "googFingerprintAlgorithm": "sha-256",
+            "googDerBase64": "MIIBFTCBvaADAgECAgkAjk/glew1VugwCgYIKoZIzj0EAwIwETEPMA0GA1UEAwwGV2ViUlRDMB4XDTE2MDYxNjEyMTMzNVoXDTE2MDcxNzEyMTMzNVowETEPMA0GA1UEAwwGV2ViUlRDMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV1SaRCZhWrVpOWtyFvKjALDF2AUiLcaQW44UQyDtWGY9ZvyB/r9IbVtMZQaWzAhgo3/MqnxAV9aI/V/LavFm8zAKBggqhkjOPQQDAgNHADBEAiAb6LGObQ+HZNHIBwZMyHnXojmRAkQtna1GNqKdbtlFnAIgLy+MS5LYT/ZJPzKlo+MmGzdZ8bd22NwN4C5waepAVd8="
+        }
+    },
+    {
+        "key": "Channel-audio-1",
+        "value": {
+            "id": "Channel-audio-1",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "1",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "Channel-audio-2",
+        "value": {
+            "id": "Channel-audio-2",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "2",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "Channel-data-1",
+        "value": {
+            "id": "Channel-data-1",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "1",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "Channel-video-1",
+        "value": {
+            "id": "Channel-video-1",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "googComponent",
+            "googComponent": "1",
+            "remoteCertificateId": "googCertificate_C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+            "selectedCandidatePairId": "Conn-video-1-0",
+            "dtlsCipher": "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9",
+            "srtpCipher": "AES_CM_128_HMAC_SHA1_80"
+        }
+    },
+    {
+        "key": "Channel-video-2",
+        "value": {
+            "id": "Channel-video-2",
+            "timestamp": "2016-06-17T12:13:36.101Z",
+            "type": "googComponent",
+            "googComponent": "2",
+            "localCertificateId": "googCertificate_B8:01:ED:58:34:CA:E4:DD:39:DF:05:B6:DF:56:85:4F:9F:58:2F:74:FB:89:EC:A7:B4:70:3F:40:C3:18:05:B9"
+        }
+    },
+    {
+        "key": "ssrc_2422518318_recv",
+        "value": {
+            "id": "ssrc_2422518318_recv",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "ssrc",
+            "googDecodingCTN": "52387",
+            "packetsLost": "23",
+            "googSecondaryDecodedRate": "0",
+            "googDecodingPLC": "46",
+            "packetsReceived": "26229",
+            "googExpandRate": "0",
+            "googJitterReceived": "2",
+            "googDecodingCNG": "0",
+            "ssrc": "2422518318",
+            "googPreferredJitterBufferMs": "20",
+            "googSpeechExpandRate": "0",
+            "googTrackId": "c25d5324-45ef-4653-8444-25b468afa76b",
+            "transportId": "Channel-video-1",
+            "mediaType": "audio",
+            "googDecodingPLCCNG": "0",
+            "googCodecName": "opus",
+            "googDecodingNormal": "52341",
+            "audioOutputLevel": "205",
+            "googAccelerateRate": "0",
+            "bytesReceived": "2689847",
+            "googCurrentDelayMs": "113",
+            "googDecodingCTSG": "0",
+            "googCaptureStartNtpTimeMs": "3675154416349",
+            "googPreemptiveExpandRate": "0",
+            "googJitterBufferMs": "84"
+        }
+    },
+    {
+        "key": "ssrc_5896877_recv",
+        "value": {
+            "id": "ssrc_5896877_recv",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "ssrc",
+            "googCaptureStartNtpTimeMs": "3675154416569",
+            "googTargetDelayMs": "80",
+            "packetsLost": "2521",
+            "googDecodeMs": "2",
+            "googFrameHeightReceived": "480",
+            "packetsReceived": "126027",
+            "ssrc": "5896877",
+            "googRenderDelayMs": "10",
+            "googMaxDecodeMs": "4",
+            "googTrackId": "91e5b7dc-28b7-45a5-8000-5b8631369493",
+            "googFrameWidthReceived": "640",
+            "codecImplementationName": "libvpx",
+            "transportId": "Channel-video-1",
+            "mediaType": "video",
+            "googCodecName": "VP8",
+            "googFrameRateReceived": "29",
+            "googFrameRateDecoded": "30",
+            "googNacksSent": "193",
+            "googFirsSent": "0",
+            "bytesReceived": "137494002",
+            "googCurrentDelayMs": "80",
+            "googMinPlayoutDelayMs": "80",
+            "googFrameRateOutput": "30",
+            "googJitterBufferMs": "29",
+            "googPlisSent": "12"
+        }
+    },
+    {
+        "key": "bweforvideo",
+        "value": {
+            "id": "bweforvideo",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "VideoBwe",
+            "googActualEncBitrate": "1781645",
+            "googAvailableSendBandwidth": "2783968",
+            "googRetransmitBitrate": "0",
+            "googAvailableReceiveBandwidth": "2676213",
+            "googTargetEncBitrate": "1700000",
+            "googBucketDelay": "0",
+            "googTransmitBitrate": "2321896"
+        }
+    },
+    {
+        "key": "googCertificate_C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+        "value": {
+            "id": "googCertificate_C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "googCertificate",
+            "googFingerprint": "C3:47:B2:74:E8:3D:3B:6D:A3:55:3C:55:D4:9C:9E:53:5E:68:98:BF",
+            "googFingerprintAlgorithm": "sha-1",
+            "googDerBase64": "MIIBsTCCARqgAwIBAgIGAVVZLuIZMA0GCSqGSIb3DQEBBQUAMBwxGjAYBgNVBAMMEUpWQiAwLjEuYnVpbGQuU1ZOMB4XDTE2MDYxNTEyMjgxMloXDTE2MDYyMzEyMjgxMlowHDEaMBgGA1UEAwwRSlZCIDAuMS5idWlsZC5TVk4wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKu0aXTYaQGUyEU75jO/OqPEQs1IIHOlOEcTGEO1WLHjbtpjSjqW3ECWwHh/MTEoslp5HsXpuyjcAwXOCbN4Nz3Z3UmGsh7Z9z29TZyTshELVDnVjxjgLOQpg43ywkZAQB/nI1Caw/3dAplMrzQa/NJ2uP3WxLNBuDt+wzeHG+1pAgMBAAEwDQYJKoZIhvcNAQEFBQADgYEAMNT5J9WK8EnJK/ZzF9kGyX+4HSwu/sJe/Uu3gN+miNdvSdQxMp9x9HTq6YCmMEDZUM5TgcuU6yTTEt7vehbxsgfjF8pamrE+eUUSjyfopwSi4Y+iktxZMoZXDlty8Xe43ZfE6pkBYF7kMDRSfvthtYPq6NOBGi4/0WusgAxHOiw="
+        }
+    },
+    {
+        "key": "Conn-video-1-0",
+        "value": {
+            "id": "Conn-video-1-0",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "googCandidatePair",
+            "responsesSent": "38",
+            "requestsReceived": "38",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "true",
+            "googLocalAddress": "172.18.176.255:64985",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "true",
+            "requestsSent": "2200",
+            "googRemoteAddress": "54.165.147.171:10000",
+            "googRtt": "11",
+            "googActiveConnection": "true",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "142176095",
+            "responsesReceived": "2197",
+            "remoteCandidateId": "Cand-INmwpWWt",
+            "localCandidateId": "Cand-wT+oPLPA",
+            "bytesSent": "139146039",
+            "packetsSent": "154801"
+        }
+    },
+    {
+        "key": "Cand-wT+oPLPA",
+        "value": {
+            "id": "Cand-wT+oPLPA",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "64985",
+            "networkType": "lan",
+            "ipAddress": "172.18.176.255",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2122260223"
+        }
+    },
+    {
+        "key": "Cand-INmwpWWt",
+        "value": {
+            "id": "Cand-INmwpWWt",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "10000",
+            "ipAddress": "54.165.147.171",
+            "transport": "udp",
+            "candidateType": "serverreflexive",
+            "priority": "1677724415"
+        }
+    },
+    {
+        "key": "Conn-video-1-1",
+        "value": {
+            "id": "Conn-video-1-1",
+            "timestamp": "2016-06-17T12:14:51.393Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "192.168.64.1:9",
+            "consentRequestsSent": "0",
+            "googTransportType": "tcp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "0",
+            "googRemoteAddress": "172.18.12.231:4443",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-37oGWafi",
+            "localCandidateId": "Cand-FBsLuZbK",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-tmvpC7tc",
+        "value": {
+            "id": "Cand-tmvpC7tc",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "10000",
+            "ipAddress": "172.18.12.231",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2130706431"
+        }
+    },
+    {
+        "key": "Conn-video-1-2",
+        "value": {
+            "id": "Conn-video-1-2",
+            "timestamp": "2016-06-17T12:13:50.739Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "192.168.64.1:50198",
+            "consentRequestsSent": "50",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "50",
+            "googRemoteAddress": "172.18.12.231:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-tmvpC7tc",
+            "localCandidateId": "Cand-wOrQ25Vv",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-wOrQ25Vv",
+        "value": {
+            "id": "Cand-wOrQ25Vv",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "50198",
+            "networkType": "lan",
+            "ipAddress": "192.168.64.1",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2122194687"
+        }
+    },
+    {
+        "key": "Conn-video-1-3",
+        "value": {
+            "id": "Conn-video-1-3",
+            "timestamp": "2016-06-17T12:13:50.739Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "false",
+            "googLocalAddress": "192.168.64.1:50198",
+            "consentRequestsSent": "50",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "50",
+            "googRemoteAddress": "54.165.147.171:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-INmwpWWt",
+            "localCandidateId": "Cand-wOrQ25Vv",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Conn-video-1-4",
+        "value": {
+            "id": "Conn-video-1-4",
+            "timestamp": "2016-06-17T12:13:50.739Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "172.18.176.255:9",
+            "consentRequestsSent": "0",
+            "googTransportType": "tcp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "0",
+            "googRemoteAddress": "172.18.12.231:4443",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-37oGWafi",
+            "localCandidateId": "Cand-MLrYwp/3",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-MLrYwp/3",
+        "value": {
+            "id": "Cand-MLrYwp/3",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "9",
+            "networkType": "lan",
+            "ipAddress": "172.18.176.255",
+            "transport": "tcp",
+            "candidateType": "host",
+            "priority": "1518280447"
+        }
+    },
+    {
+        "key": "Cand-37oGWafi",
+        "value": {
+            "id": "Cand-37oGWafi",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "4443",
+            "ipAddress": "172.18.12.231",
+            "transport": "ssltcp",
+            "candidateType": "host",
+            "priority": "2130706431"
+        }
+    },
+    {
+        "key": "Conn-video-1-5",
+        "value": {
+            "id": "Conn-video-1-5",
+            "timestamp": "2016-06-17T12:13:50.739Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "192.168.64.1:9",
+            "consentRequestsSent": "0",
+            "googTransportType": "tcp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "0",
+            "googRemoteAddress": "172.18.12.231:4443",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-37oGWafi",
+            "localCandidateId": "Cand-FBsLuZbK",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-4LkPxWAa",
+        "value": {
+            "id": "Cand-4LkPxWAa",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "remotecandidate",
+            "portNumber": "4443",
+            "ipAddress": "54.165.147.171",
+            "transport": "ssltcp",
+            "candidateType": "serverreflexive",
+            "priority": "1694498815"
+        }
+    },
+    {
+        "key": "Conn-video-1-6",
+        "value": {
+            "id": "Conn-video-1-6",
+            "timestamp": "2016-06-17T12:13:50.739Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "54.210.139.169:61927",
+            "consentRequestsSent": "50",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "relay",
+            "googWritable": "false",
+            "requestsSent": "50",
+            "googRemoteAddress": "172.18.12.231:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-tmvpC7tc",
+            "localCandidateId": "Cand-YiNpVTvy",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-FBsLuZbK",
+        "value": {
+            "id": "Cand-FBsLuZbK",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "9",
+            "networkType": "lan",
+            "ipAddress": "192.168.64.1",
+            "transport": "tcp",
+            "candidateType": "host",
+            "priority": "1518214911"
+        }
+    },
+    {
+        "key": "Conn-video-1-7",
+        "value": {
+            "id": "Conn-video-1-7",
+            "timestamp": "2016-06-17T12:13:50.739Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "false",
+            "googLocalAddress": "54.210.139.169:61927",
+            "consentRequestsSent": "50",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "relay",
+            "googWritable": "false",
+            "requestsSent": "50",
+            "googRemoteAddress": "54.165.147.171:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-INmwpWWt",
+            "localCandidateId": "Cand-YiNpVTvy",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-YiNpVTvy",
+        "value": {
+            "id": "Cand-YiNpVTvy",
+            "timestamp": "2016-06-17T12:13:36.395Z",
+            "type": "localcandidate",
+            "portNumber": "61927",
+            "networkType": "lan",
+            "ipAddress": "54.210.139.169",
+            "transport": "udp",
+            "candidateType": "relayed",
+            "priority": "41885439"
+        }
+    },
+    {
+        "key": "Conn-video-1-8",
+        "value": {
+            "id": "Conn-video-1-8",
+            "timestamp": "2016-06-17T12:13:40.492Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "false",
+            "googLocalAddress": "54.210.139.169:61927",
+            "consentRequestsSent": "14",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "relay",
+            "googWritable": "false",
+            "requestsSent": "14",
+            "googRemoteAddress": "54.165.147.171:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-INmwpWWt",
+            "localCandidateId": "Cand-YiNpVTvy",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "ssrc_3923207368_send",
+        "value": {
+            "id": "ssrc_3923207368_send",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "ssrc",
+            "audioInputLevel": "84",
+            "packetsLost": "18",
+            "googRtt": "23",
+            "googEchoCancellationReturnLossEnhancement": "-100",
+            "googTrackId": "47d11ec3-fc64-44ab-a839-1659aadf8d48",
+            "transportId": "Channel-video-1",
+            "mediaType": "audio",
+            "aecDivergentFilterFraction": "0",
+            "googEchoCancellationReturnLoss": "-100",
+            "googCodecName": "opus",
+            "googEchoCancellationEchoDelayMedian": "4",
+            "ssrc": "3923207368",
+            "googJitterReceived": "2",
+            "googTypingNoiseState": "false",
+            "packetsSent": "26252",
+            "bytesSent": "2693176",
+            "googEchoCancellationEchoDelayStdDev": "0"
+        }
+    },
+    {
+        "key": "ssrc_1169081302_send",
+        "value": {
+            "id": "ssrc_1169081302_send",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "ssrc",
+            "googFrameHeightInput": "480",
+            "googFrameWidthInput": "640",
+            "googFrameWidthSent": "640",
+            "packetsLost": "10000",
+            "googRtt": "23",
+            "googEncodeUsagePercent": "13",
+            "googCpuLimitedResolution": "false",
+            "googNacksReceived": "34",
+            "googViewLimitedResolution": "false",
+            "googBandwidthLimitedResolution": "false",
+            "googPlisReceived": "0",
+            "googAvgEncodeMs": "6",
+            "googTrackId": "3b137021-f636-4767-bd02-d5361708047d",
+            "googFrameRateInput": "29",
+            "codecImplementationName": "libvpx",
+            "transportId": "Channel-video-1",
+            "mediaType": "video",
+            "googFrameHeightSent": "480",
+            "googFrameRateSent": "30",
+            "googCodecName": "VP8",
+            "googAdaptationChanges": "0",
+            "ssrc": "1169081302",
+            "googFirsReceived": "0",
+            "packetsSent": "123427",
+            "bytesSent": "134510871"
+        }
+    },
+    {
+        "key": "datachannel_0",
+        "value": {
+            "id": "datachannel_0",
+            "timestamp": "2016-06-17T12:22:21.374Z",
+            "type": "datachannel",
+            "datachannelid": "0",
+            "protocol": "http://jitsi.org/protocols/colibri",
+            "label": "default",
+            "state": "open"
+        }
+    }
+]

--- a/test/mock-stats-3-spec.json
+++ b/test/mock-stats-3-spec.json
@@ -1,0 +1,229 @@
+[
+    {
+        "key": "googLibjingleSession_6589355560001646871",
+        "value": {
+            "id": "googLibjingleSession_6589355560001646871",
+            "timestamp": "2016-11-14T17:07:15.785Z",
+            "type": "googLibjingleSession",
+            "googInitiator": "false"
+        }
+    },
+    {
+        "key": "googTrack_ebdad64b-7969-406e-9e70-7a59f10d05fa",
+        "value": {
+            "id": "googTrack_ebdad64b-7969-406e-9e70-7a59f10d05fa",
+            "timestamp": "2016-11-14T17:07:15.785Z",
+            "type": "googTrack",
+            "googTrackId": "ebdad64b-7969-406e-9e70-7a59f10d05fa"
+        }
+    },
+    {
+        "key": "googCertificate_CC:AF:65:0B:54:9F:BC:69:B2:BB:3C:2D:C2:0F:68:DA:29:FB:AA:BB:1C:FB:6E:64:D9:55:2D:B5:C2:42:5D:FE",
+        "value": {
+            "id": "googCertificate_CC:AF:65:0B:54:9F:BC:69:B2:BB:3C:2D:C2:0F:68:DA:29:FB:AA:BB:1C:FB:6E:64:D9:55:2D:B5:C2:42:5D:FE",
+            "timestamp": "2016-11-14T17:07:15.785Z",
+            "type": "googCertificate",
+            "googFingerprint": "CC:AF:65:0B:54:9F:BC:69:B2:BB:3C:2D:C2:0F:68:DA:29:FB:AA:BB:1C:FB:6E:64:D9:55:2D:B5:C2:42:5D:FE",
+            "googFingerprintAlgorithm": "sha-256",
+            "googDerBase64": "MIIBFjCBvaADAgECAgkAtbAjHNEOshMwCgYIKoZIzj0EAwIwETEPMA0GA1UEAwwGV2ViUlRDMB4XDTE2MTExMzE3MDMxMloXDTE2MTIxNDE3MDMxMlowETEPMA0GA1UEAwwGV2ViUlRDMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/W5Qwb1rOszjrYjs4YLIyWKuSrJWXSuXXD67NzMunBLinMxV6/t41qkJ0V0qeq1tpHv4lAasspqOB/IItsV5ATAKBggqhkjOPQQDAgNIADBFAiEAmi+oQxgzuAB15yOd4uV+FGQIvvqJDsDUV0wZbUdjH8gCIBp/wpb7Ytd9PyEVNTebzZ+AAXmNEz2yZ5wfE1ldxuLT"
+        }
+    },
+    {
+        "key": "googCertificate_5C:05:60:EC:57:EF:5C:3F:72:4E:B7:D9:E9:B2:1C:78:BB:E6:D6:AD",
+        "value": {
+            "id": "googCertificate_5C:05:60:EC:57:EF:5C:3F:72:4E:B7:D9:E9:B2:1C:78:BB:E6:D6:AD",
+            "timestamp": "2016-11-14T17:07:15.785Z",
+            "type": "googCertificate",
+            "googFingerprint": "5C:05:60:EC:57:EF:5C:3F:72:4E:B7:D9:E9:B2:1C:78:BB:E6:D6:AD",
+            "googFingerprintAlgorithm": "sha-1",
+            "googDerBase64": "MIIBsTCCARqgAwIBAgIGAVhezfYgMA0GCSqGSIb3DQEBBQUAMBwxGjAYBgNVBAMMEUpWQiAwLjEuYnVpbGQuU1ZOMB4XDTE2MTExMjE3NDgyNloXDTE2MTEyMDE3NDgyNlowHDEaMBgGA1UEAwwRSlZCIDAuMS5idWlsZC5TVk4wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBALDbNzg5g9mMp/PubjLzUlTgHqp+0EKlGztKzrbzU2SHR5O5cpp1ccJp/FBYJLHT8s6czjM+Vj6kvbKN6Znv3CprIiyps1/JbvZe53xJUApXLF+LVuxeSILGbDJyNmdsZA9/2289UvnpnjQ2gwL/3FG48PnvvxzH/DttIU6hxqKBAgMBAAEwDQYJKoZIhvcNAQEFBQADgYEAHjMSSzw/lU8CGxvKUyB2PWwdceYaOPzdfNZS5iGxr/Ye25shBMZFtBTRSy7qliofG1nNIABXlE9oQyaEKJ9Jfj3is6m9mShyG8FZJGgqaCgHKVMpXIxdZOC4PqRfcvRzPgTgPD4h5sUlS8CRJ6Tl8xHMZnHlxxjOVlPeuM7wdQM="
+        }
+    },
+    {
+        "key": "Channel-video-1",
+        "value": {
+            "id": "Channel-video-1",
+            "timestamp": "2016-11-14T17:07:15.785Z",
+            "type": "googComponent",
+            "googComponent": "1",
+            "remoteCertificateId": "googCertificate_5C:05:60:EC:57:EF:5C:3F:72:4E:B7:D9:E9:B2:1C:78:BB:E6:D6:AD",
+            "selectedCandidatePairId": "Conn-video-1-0",
+            "dtlsCipher": "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "localCertificateId": "googCertificate_CC:AF:65:0B:54:9F:BC:69:B2:BB:3C:2D:C2:0F:68:DA:29:FB:AA:BB:1C:FB:6E:64:D9:55:2D:B5:C2:42:5D:FE",
+            "srtpCipher": "AES_CM_128_HMAC_SHA1_80"
+        }
+    },
+    {
+        "key": "Conn-video-1-0",
+        "value": {
+            "id": "Conn-video-1-0",
+            "timestamp": "2016-11-14T17:07:15.785Z",
+            "type": "googCandidatePair",
+            "responsesSent": "20",
+            "requestsReceived": "20",
+            "googRemoteCandidateType": "stun",
+            "googReadable": "true",
+            "googLocalAddress": "168.215.121.230:52682",
+            "consentRequestsSent": "1",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "stun",
+            "googWritable": "true",
+            "requestsSent": "101",
+            "googRemoteAddress": "52.91.179.27:10000",
+            "googRtt": "18",
+            "googActiveConnection": "true",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "3601571",
+            "responsesReceived": "101",
+            "remoteCandidateId": "Cand-Yl5VkoLs",
+            "localCandidateId": "Cand-++5AM3jF",
+            "bytesSent": "138870",
+            "packetsSent": "1078"
+        }
+    },
+    {
+        "key": "Cand-++5AM3jF",
+        "value": {
+            "id": "Cand-++5AM3jF",
+            "timestamp": "2016-11-14T17:03:12.580Z",
+            "type": "localcandidate",
+            "portNumber": "52682",
+            "networkType": "wlan",
+            "ipAddress": "168.215.121.230",
+            "transport": "udp",
+            "candidateType": "serverreflexive",
+            "priority": "1685987071"
+        }
+    },
+    {
+        "key": "Cand-Yl5VkoLs",
+        "value": {
+            "id": "Cand-Yl5VkoLs",
+            "timestamp": "2016-11-14T17:03:12.580Z",
+            "type": "remotecandidate",
+            "portNumber": "10000",
+            "ipAddress": "52.91.179.27",
+            "transport": "udp",
+            "candidateType": "serverreflexive",
+            "priority": "1677724415"
+        }
+    },
+    {
+        "key": "Conn-video-1-1",
+        "value": {
+            "id": "Conn-video-1-1",
+            "timestamp": "2016-11-14T17:03:12.580Z",
+            "type": "googCandidatePair",
+            "responsesSent": "0",
+            "requestsReceived": "0",
+            "googRemoteCandidateType": "local",
+            "googReadable": "false",
+            "googLocalAddress": "172.18.178.55:52682",
+            "consentRequestsSent": "3",
+            "googTransportType": "udp",
+            "googChannelId": "Channel-video-1",
+            "googLocalCandidateType": "local",
+            "googWritable": "false",
+            "requestsSent": "3",
+            "googRemoteAddress": "172.18.24.221:10000",
+            "googRtt": "3000",
+            "googActiveConnection": "false",
+            "packetsDiscardedOnSend": "0",
+            "bytesReceived": "0",
+            "responsesReceived": "0",
+            "remoteCandidateId": "Cand-6qQBPMK4",
+            "localCandidateId": "Cand-45EwxuFE",
+            "bytesSent": "0",
+            "packetsSent": "0"
+        }
+    },
+    {
+        "key": "Cand-45EwxuFE",
+        "value": {
+            "id": "Cand-45EwxuFE",
+            "timestamp": "2016-11-14T17:03:12.580Z",
+            "type": "localcandidate",
+            "portNumber": "52682",
+            "networkType": "wlan",
+            "ipAddress": "172.18.178.55",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2122194687"
+        }
+    },
+    {
+        "key": "Cand-6qQBPMK4",
+        "value": {
+            "id": "Cand-6qQBPMK4",
+            "timestamp": "2016-11-14T17:03:12.580Z",
+            "type": "remotecandidate",
+            "portNumber": "10000",
+            "ipAddress": "172.18.24.221",
+            "transport": "udp",
+            "candidateType": "host",
+            "priority": "2130706431"
+        }
+    },
+    {
+        "key": "ssrc_4149875181_recv",
+        "value": {
+            "id": "ssrc_4149875181_recv",
+            "timestamp": "2016-11-14T17:07:15.785Z",
+            "type": "ssrc",
+            "googCaptureStartNtpTimeMs": "0",
+            "googTargetDelayMs": "373",
+            "packetsLost": "20",
+            "googDecodeMs": "3",
+            "googFrameHeightReceived": "602",
+            "packetsReceived": "5276",
+            "ssrc": "4149875181",
+            "googFrameRateDecoded": "15",
+            "googMaxDecodeMs": "3",
+            "googTrackId": "ebdad64b-7969-406e-9e70-7a59f10d05fa",
+            "googFrameWidthReceived": "1440",
+            "codecImplementationName": "libvpx",
+            "transportId": "Channel-video-1",
+            "mediaType": "video",
+            "googCodecName": "VP8",
+            "googFrameRateReceived": "14",
+            "framesDecoded": "3243",
+            "googNacksSent": "19",
+            "googFirsSent": "0",
+            "bytesReceived": "3519798",
+            "googCurrentDelayMs": "373",
+            "googRenderDelayMs": "10",
+            "googMinPlayoutDelayMs": "0",
+            "googFrameRateOutput": "15",
+            "googJitterBufferMs": "360",
+            "googPlisSent": "2"
+        }
+    },
+    {
+        "key": "bweforvideo",
+        "value": {
+            "id": "bweforvideo",
+            "timestamp": "2016-11-14T17:07:15.785Z",
+            "type": "VideoBwe",
+            "googActualEncBitrate": "0",
+            "googAvailableSendBandwidth": "300000",
+            "googRetransmitBitrate": "0",
+            "googAvailableReceiveBandwidth": "315028",
+            "googTargetEncBitrate": "0",
+            "googBucketDelay": "0",
+            "googTransmitBitrate": "0"
+        }
+    },
+    {
+        "key": "datachannel_0",
+        "value": {
+            "id": "datachannel_0",
+            "timestamp": "2016-11-14T17:07:15.785Z",
+            "type": "datachannel",
+            "datachannelid": "0",
+            "protocol": "http://jitsi.org/protocols/colibri",
+            "label": "default",
+            "state": "open"
+        }
+    }
+]

--- a/test/test-spec.js
+++ b/test/test-spec.js
@@ -22,9 +22,9 @@ import { assert } from 'chai';
 import sinon from 'sinon';
 import StatsGatherer from '../src/StatsGatherer';
 import mockInitialStats from './mock-initial-stats.json';
-import mockStats1 from './mock-stats-1.json';
-import mockStats2 from './mock-stats-2.json';
-import mockStats3 from './mock-stats-3.json';
+import mockStats1 from './mock-stats-1-spec.json';
+import mockStats2 from './mock-stats-2-spec.json';
+import mockStats3 from './mock-stats-3-spec.json';
 import mockSdp from './mock-sdp.json';
 import { EventEmitter } from 'events';
 
@@ -83,8 +83,9 @@ describe('StatsGatherer', function () {
 
     describe('intervalLoss', function () {
       it('should generate intervalLoss', function () {
-        const stats1 = {
-          'ssrc_2422518318_recv': {
+        const stats1 = [{
+          key: 'ssrc_2422518318_recv',
+          value: {
             'id': 'ssrc_2422518318_recv',
             'timestamp': '2016-06-17T12:22:21.374Z',
             'type': 'ssrc',
@@ -97,10 +98,11 @@ describe('StatsGatherer', function () {
             'googCodecName': 'opus',
             'bytesReceived': '0'
           }
-        };
+        }];
 
-        const stats2 = {
-          'ssrc_2422518318_recv': {
+        const stats2 = [{
+          key: 'ssrc_2422518318_recv',
+          value: {
             'id': 'ssrc_2422518318_recv',
             'timestamp': '2016-06-17T12:22:21.374Z',
             'type': 'ssrc',
@@ -113,10 +115,11 @@ describe('StatsGatherer', function () {
             'googCodecName': 'opus',
             'bytesReceived': '0'
           }
-        };
+        }];
 
-        const stats3 = {
-          'ssrc_2422518318_recv': {
+        const stats3 = [{
+          key: 'ssrc_2422518318_recv',
+          value: {
             'id': 'ssrc_2422518318_recv',
             'timestamp': '2016-06-17T12:22:21.374Z',
             'type': 'ssrc',
@@ -129,7 +132,7 @@ describe('StatsGatherer', function () {
             'googCodecName': 'opus',
             'bytesReceived': '0'
           }
-        };
+        }];
 
         report1 = gatherer._createStatsReport(stats1, true);
         report2 = gatherer._createStatsReport(stats2, true);


### PR DESCRIPTION
This'll be a major version bump since it's a big refactor. In reality, it should be entirely backward compatible, but no point in forcing a minor version.

This makes the gatherer compatible with the new spec compliant version of getStats which will be provided in chrome 58, and via any use of adapter.js v3.x