### PR TITLE
add browserify to root of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "check:coverage": "./scripts/checkCoverage.sh",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
+  "browserify": {
+    "transform": ["babelify"]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mypurecloud/webrtc-stats-gatherer.git"


### PR DESCRIPTION
projects that use this module that use browserify
can then use it without any hacks when the source
is transformed. Without this - babel/browserify
complains