### PR TITLE
[STREAM-69] Return an empty array for stats for other connection states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keepa Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 PCM-2326
 # [Unreleased](https://github.com/mypurecloud/webrtc-stats-gatherer/compare/v9.0.8...HEAD)
-* [STREAM-32] Update dev dependencies, switch to ESLint, add Prettier
+* [STREAM-32](https://inindca.atlassian.net/browse/STREAM-32) Update dev dependencies, switch to ESLint, add Prettier
+* [STREAM-69](https://inindca.atlassian.net/browse/STREAM-69) Return an empty array when gathering stats for other states like `disconnected` to prevent errors in callers when network connectivity drops
 
 # [v9.0.8](https://github.com/mypurecloud/webrtc-stats-gatherer/compare/v9.0.6...v9.0.8)
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,7 +262,7 @@ export default class StatsGatherer extends EventEmitter {
 
     const statsPoll = () => {
       return this.gatherStats().then((reports) => {
-        if (reports.length == 0) {
+        if (reports.length === 0) {
           this.logger.warn('Empty stats gathered, ignoring and not emitting stats');
           return;
         }
@@ -373,7 +373,7 @@ export default class StatsGatherer extends EventEmitter {
       remoteTracks: [],
     };
 
-    if (results.length == 0) {
+    if (results.length === 0) {
       return event;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,6 +341,8 @@ export default class StatsGatherer extends EventEmitter {
           this.pollingInterval = null;
         }
         return [];
+      } else {
+        return [];
       }
     } catch (e) {
       this.logger.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,7 +232,7 @@ export default class StatsGatherer extends EventEmitter {
     }
   }
 
-  private async handleConnectionStateChange() {
+  private handleConnectionStateChange() {
     const state = this.peerConnection.connectionState;
 
     if (state === 'connected') {
@@ -242,11 +242,16 @@ export default class StatsGatherer extends EventEmitter {
         return;
       }
 
-      return this.gatherStats().then((reports) => {
-        const event = this.createStatsReport(reports);
-        event.type = 'disconnected';
-        this.emit('stats', event);
-      });
+      const event: GetStatsEvent = {
+        type: 'disconnected',
+        name: 'getStats',
+        session: this.session,
+        initiator: this.initiator,
+        conference: this.conference,
+        tracks: [],
+        remoteTracks: [],
+      };
+      this.emit('stats', event);
     } else if (['closed', 'failed'].includes(state) && this.pollingInterval) {
       if (IS_BROWSER) {
         window.clearInterval(this.pollingInterval);

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,11 @@ export default class StatsGatherer extends EventEmitter {
 
     const statsPoll = () => {
       return this.gatherStats().then((reports) => {
+        if (reports.length == 0) {
+          this.logger.warn('Empty stats gathered, ignoring and not emitting stats');
+          return;
+        }
+
         const event = this.createStatsReport(reports, true);
         if (event.tracks.length > 0 || event.remoteTracks.length > 0) {
           // If the last five stat events have a remote bitrate of 0, stop emitting.

--- a/test/test.ts
+++ b/test/test.ts
@@ -409,6 +409,14 @@ describe('StatsGatherer', () => {
       expect.assertions(4);
       jest.resetAllMocks();
     });
+
+    it('should return an empty array for other states (e.g. disconnected)', async () => {
+      rtcPeerConnection.connectionState = 'disconnected';
+      const gatherer = new StatsGatherer(rtcPeerConnection);
+
+      const result = await gatherer['gatherStats']();
+      expect(result).toStrictEqual([]);
+    });
   });
 
   describe('polyFillStats', () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -508,6 +508,21 @@ describe('StatsGatherer', () => {
       expect(timeout).not.toHaveBeenCalled();
       expect(interval).not.toHaveBeenCalled();
     });
+
+    it('should ignore empty stats', async () => {
+      const gatherer = new StatsGatherer(rtcPeerConnection);
+
+      const timeout = jest.spyOn(window, 'setTimeout');
+      gatherer['pollForStats']();
+      const statsPollFn = timeout.mock.calls[0][0];
+
+      const gatherSpy = jest.spyOn(gatherer as any, 'gatherStats').mockResolvedValue([]);
+      const reportSpy = jest.spyOn(gatherer as any, 'createStatsReport');
+
+      await statsPollFn();
+
+      expect(reportSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('checkBitrate', () => {


### PR DESCRIPTION
This change fixes errors such as the following that occur when network connectivity is lost and the PeerConnection goes to `disconnected`:

```
Error: Uncaught (in promise): TypeError: Cannot read properties of undefined (reading 'filter')
TypeError: Cannot read properties of undefined (reading 'filter')
    at push.89726.StatsGatherer.createStatsReport (index.js:387:1)
```

I originally just looked for `undefined` in a couple of callers, but this seems like a safe way to handle any other connection state and all callers.